### PR TITLE
Upgraded to sbt 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,20 @@
 
 This is an sbt plugin that sbt-web plugins can use to get their configuration.
 
+[![Build Status](https://travis-ci.org/sbt/sbt-web-build-base.svg?branch=master)](https://travis-ci.org/sbt/sbt-web-build-base) [![Download](https://api.bintray.com/packages/sbt-web/sbt-plugin-releases/sbt-web-build-base/images/download.svg)](https://bintray.com/sbt-web/sbt-plugin-releases/sbt-web-build-base/_latestVersion)
+
 ## Usage
 
-Ensure that `project/build.properties` is configured for sbt 0.13.16:
+Ensure that `project/build.properties` is configured for sbt minimum version of 1.0.1:
 
 ```
-sbt.version=0.13.16
+sbt.version=1.0.1
 ```
 
 Add the following to `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.typesafe.sbt" % "sbt-web-build-base" % "1.1.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-web-build-base" % "1.2.0")
 ```
 
 Now create a `version.sbt` with the version declared in it, for example:

--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ description := "Base build plugin for all sbt-web plugins"
 addSbtPlugin("com.github.gseitz" % "sbt-release" % sbtReleaseVersion)
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % sbtPgpVersion)
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % sbtBintrayVersion)
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % scriptedPluginVersion
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % scriptedPluginVersion
 
-crossSbtVersions := Seq("0.13.16")
+crossSbtVersions := Seq("1.0.1")
 
 addCommandAlias("validate", ";clean;test;scripted")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.1

--- a/project/project.sbt
+++ b/project/project.sbt
@@ -1,9 +1,9 @@
 import java.util.Locale
 
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 
 lazy val build = (project in file(".")).

--- a/src/sbt-test/sbt-web-build-base/check-settings/build.sbt
+++ b/src/sbt-test/sbt-web-build-base/check-settings/build.sbt
@@ -14,5 +14,5 @@ TaskKey[Unit]("testSettings") := {
   assertEquals(releaseVersion.value("1.0"), "1.0")
 }
 
-addSbtJsEngine("1.1.1")
-addSbtWeb("1.2.0")
+addSbtJsEngine("1.2.2")
+addSbtWeb("1.4.2")

--- a/src/sbt-test/sbt-web-build-base/check-settings/test
+++ b/src/sbt-test/sbt-web-build-base/check-settings/test
@@ -1,2 +1,7 @@
-> update
+> ^update
+
+# Make sure resolution was done for both sbt 0.13 and sbt 1.0
+$ exists target/scala-2.10/sbt-0.13/resolution-cache/com.typesafe.sbt/check-settings/scala_2.10/sbt_0.13/0.1-SNAPSHOT/resolved.xml.xml
+$ exists target/scala-2.12/sbt-1.0/resolution-cache/com.typesafe.sbt/check-settings/scala_2.12/sbt_1.0/0.1-SNAPSHOT/resolved.xml.xml
+
 > testSettings


### PR DESCRIPTION
This switches so that sbt-web plugins can now actually use sbt 1.0 to build themselves (not just cross build against it).