### PR TITLE
Downgrade sbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ sbt.version=1.2.1
 Add the following to `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.typesafe.sbt" % "sbt-web-build-base" % "1.3.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-web-build-base" % "1.2.3")
 ```
 
 Now create a `version.sbt` with the version declared in it, for example:

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,8 @@ addSbtPlugin("io.crashbox" % "sbt-gpg" % sbtGpgVersion)
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % sbtBintrayVersion)
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % scriptedPluginVersion
 
-crossSbtVersions := Seq("1.3.4")
+// Do not switch to sbt 1.3.x (or greater) as long as Play is build with sbt 1.2.x
+// See https://github.com/sbt/sbt/issues/5049
+crossSbtVersions := Seq("1.2.8")
 
 addCommandAlias("validate", ";clean;test;scripted")

--- a/src/main/scala/SbtWebBuildBase.scala
+++ b/src/main/scala/SbtWebBuildBase.scala
@@ -40,7 +40,9 @@ object SbtWebBase extends AutoPlugin {
     sbtPlugin := true,
     scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings"),
 
-    crossSbtVersions := Seq("0.13.18", "1.3.4"),
+    // Do not switch to sbt 1.3.x (or greater) as long as Play is build with sbt 1.2.x
+    // See https://github.com/sbt/sbt/issues/5049
+    crossSbtVersions := Seq("0.13.18", "1.2.8"),
 
     ScriptedPlugin.autoImport.scriptedLaunchOpts ++= Seq(
       "-XX:MaxMetaspaceSize=256m",


### PR DESCRIPTION
@jroper please see https://github.com/sbt/sbt/issues/5049. If I got that right I think we should also stay with sbt 1.2.x here for a while as well. The sbt version used to build the Play plugin(s) was downgraded to 1.2.8 as well for now: https://github.com/playframework/interplay/pull/99