### PR TITLE
Use `-Werror` instead of `-Xfatal-warnings`

### DIFF
--- a/src/main/scala/SbtWebBuildBase.scala
+++ b/src/main/scala/SbtWebBuildBase.scala
@@ -30,7 +30,7 @@ object SbtWebBase extends AutoPlugin {
     homepage := Some(url(s"https://github.com/sbt/${name.value}")),
     licenses := Seq(License.Apache2),
     sbtPlugin := true,
-    scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings"),
+    scalacOptions ++= Seq("-deprecation", "-feature", "-Werror"),
 
     crossSbtVersions := Seq("1.11.7"),
 


### PR DESCRIPTION
 `-Xfatal-warnings` is deprecated since Scala 3.8 https://github.com/scala/scala3/commit/0470ec1ff46a822ca58e204587fb67d56004623a